### PR TITLE
Updates Outdated User Activity URI

### DIFF
--- a/lib/user-activity-webhook.js
+++ b/lib/user-activity-webhook.js
@@ -8,14 +8,14 @@ const request = require('request');
 let twitterServerTimeOffset = 0;
 
 const TWITTER_API_URI = 'https://api.twitter.com/1.1/';
-const { sendApiRequest, rfc1738 } = require('./helpers');
+const {sendApiRequest, rfc1738} = require('./helpers');
 
-module.exports = function userActivityWebhook(config) {
+module.exports = function userActivityWebhook (config) {
     let serverUrl, route, callbackUrl, consumerSecret, consumerKey, accessToken, accessTokenSecret, environment, appBearerToken;
 
     const userActivityEmitters = new Map();
 
-    function prepareUserContextRequest(args) {
+    function prepareUserContextRequest (args) {
         if (!args.userId) throw new Error('Twitter webhooks : You must provide userId');
         if (!args.accessToken) throw new Error('Twitter webhooks : You must provide user accessToken');
         if (!args.accessTokenSecret) throw new Error('Twitter webhooks : You must provide user accessTokenSecret');
@@ -32,7 +32,7 @@ module.exports = function userActivityWebhook(config) {
         };
     }
 
-    function prepareAppContextRequest(args) {
+    function prepareAppContextRequest (args) {
         const accessTokenOption = args.accessToken || accessToken;
         const accessTokenSecretOption = args.accessTokenSecret || accessTokenSecret;
         if (typeof accessTokenOption !== 'string') throw new Error('Twitter webhooks : You must provide your app accessToken');
@@ -50,7 +50,7 @@ module.exports = function userActivityWebhook(config) {
         };
     }
 
-    function prepareAppOnlyRequest(args) {
+    function prepareAppOnlyRequest (args) {
         const appBearerTokenOption = args.appBearerToken || appBearerToken;
         if (typeof appBearerTokenOption !== 'string') {
 
@@ -65,22 +65,22 @@ module.exports = function userActivityWebhook(config) {
                     name: 'content-type',
                     value: 'application/x-www-form-urlencoded;charset=UTF-8'
                 }],
-                form: { grant_type: 'client_credentials' }
+                form: {grant_type: 'client_credentials'}
             })
-                .then((response) => {
-                    try {
-                        appBearerToken = JSON.parse(response.body).access_token;
-                        if (typeof appBearerToken !== 'string') throw new Error();
-                    } catch (e) {
-                        throw new Error('Twitter webhooks : cannot get app bearer token. Invalid response sent by twitter : ' + response.body);
+            .then((response) => {
+                try {
+                    appBearerToken = JSON.parse(response.body).access_token;
+                    if (typeof appBearerToken !== 'string') throw new Error();
+                } catch (e) {
+                    throw new Error('Twitter webhooks : cannot get app bearer token. Invalid response sent by twitter : ' + response.body);
+                }
+                return {
+                    json: true,
+                    auth: {
+                        bearer: appBearerToken
                     }
-                    return {
-                        json: true,
-                        auth: {
-                            bearer: appBearerToken
-                        }
-                    };
-                });
+                };
+            });
         } else {
             return Promise.resolve({
                 json: true,
@@ -91,54 +91,54 @@ module.exports = function userActivityWebhook(config) {
         }
     }
 
-    const middleware = function userActivityWebhookMiddleware(req, res, next) {
+    const middleware = function userActivityWebhookMiddleware (req, res, next) {
         switch (req.method) {
-            case 'GET':
-                if (req.query.crc_token) {
-                    console.log({
-                        response_token: crypto.createHmac('sha256', consumerSecret).update(req.query.crc_token).digest('base64')
-                    });
-                    return res.json({
-                        response_token: 'sha256=' + crypto.createHmac('sha256', consumerSecret).update(req.query.crc_token).digest('base64')
-                    });
-                }
-                break;
-            case 'POST':
-                res.sendStatus(200);
-                const payload = req.body;
-                if (typeof payload.for_user_id === 'string') {
-                    const emitter = userActivityEmitters.get(payload.for_user_id);
-                    for (let eventName in payload) {
-                        if (eventName === 'for_user_id') continue;
-                        const events = payload[eventName];
-                        eventName = eventName.replace('_events', '');
-                        if (Array.isArray(events)) {
-                            for (let i = 0; i < events.length; i++) {
-                                if (emitter) emitter.emit(eventName, events[i]);
-                                middleware.emit('event', eventName, payload.for_user_id, events[i]);
-                            }
-                        } else {
-                            if (emitter) emitter.emit(eventName, events);
-                            middleware.emit('event', eventName, payload.for_user_id, events);
+        case 'GET':
+            if (req.query.crc_token) {
+                console.log({
+                    response_token: crypto.createHmac('sha256', consumerSecret).update(req.query.crc_token).digest('base64')
+                });
+                return res.json({
+                    response_token: 'sha256=' + crypto.createHmac('sha256', consumerSecret).update(req.query.crc_token).digest('base64')
+                });
+            }
+            break;
+        case 'POST':
+            res.sendStatus(200);
+            const payload = req.body;
+            if (typeof payload.for_user_id === 'string') {
+                const emitter = userActivityEmitters.get(payload.for_user_id);
+                for (let eventName in payload) {
+                    if (eventName === 'for_user_id') continue;
+                    const events = payload[eventName];
+                    eventName = eventName.replace('_events', '');
+                    if (Array.isArray(events)) {
+                        for (let i = 0; i < events.length; i++) {
+                            if (emitter) emitter.emit(eventName, events[i]);
+                            middleware.emit('event', eventName, payload.for_user_id, events[i]);
                         }
-                    }
-                    return;
-                } else if (payload.user_event && typeof payload.user_event === 'object') {
-                    if (payload.user_event.revoke && typeof payload.user_event.revoke === 'object') {
-                        const emitter = userActivityEmitters.get(payload.user_event.revoke.source.user_id);
-                        if (emitter) emitter.emit('revoke', payload.user_event.revoke);
-                        middleware.emit('event', 'revoke', payload.user_event.revoke.source.user_id, payload.user_event.revoke);
-                        return;
+                    } else {
+                        if (emitter) emitter.emit(eventName, events);
+                        middleware.emit('event', eventName, payload.for_user_id, events);
                     }
                 }
-                middleware.emit('unknown-event', payload);
-                break;
+                return;
+            } else if (payload.user_event && typeof payload.user_event === 'object') {
+                if (payload.user_event.revoke && typeof payload.user_event.revoke === 'object') {
+                    const emitter = userActivityEmitters.get(payload.user_event.revoke.source.user_id);
+                    if (emitter) emitter.emit('revoke', payload.user_event.revoke);
+                    middleware.emit('event', 'revoke', payload.user_event.revoke.source.user_id, payload.user_event.revoke);
+                    return;
+                }
+            }
+            middleware.emit('unknown-event', payload);
+            break;
         }
 
         next();
     };
 
-    middleware.subscribe = function subscribe(args = {}) {
+    middleware.subscribe = function subscribe (args = {}) {
         const options = prepareUserContextRequest(args);
 
         args = Object.assign({}, args);
@@ -146,12 +146,12 @@ module.exports = function userActivityWebhook(config) {
         options.method = 'POST';
 
         return sendApiRequest(options)
-            .then(function () {
-                return middleware.getUserActivity(args);
-            });
+        .then(function () {
+            return middleware.getUserActivity(args);
+        });
     };
 
-    middleware.unsubscribe = function unsubscribe(args = {}) {
+    middleware.unsubscribe = function unsubscribe (args = {}) {
         const options = prepareUserContextRequest(args);
         const userId = args.userId;
 
@@ -159,17 +159,17 @@ module.exports = function userActivityWebhook(config) {
         options.method = 'DELETE';
 
         return sendApiRequest(options)
-            .then(function () {
-                const emitter = userActivityEmitters.get(userId);
-                if (emitter) {
-                    emitter.emit('unsubscribe');
-                    userActivityEmitters.delete(userId);
-                    emitter.removeAllListeners();
-                }
-            });
+        .then(function () {
+            const emitter = userActivityEmitters.get(userId);
+            if (emitter) {
+                emitter.emit('unsubscribe');
+                userActivityEmitters.delete(userId);
+                emitter.removeAllListeners();
+            }
+        });
     };
 
-    middleware.register = function register(args = {}) {
+    middleware.register = function register (args = {}) {
         const options = prepareAppContextRequest(args);
         const callbackUrlOption = args.callbackUrl || callbackUrl;
         if (typeof callbackUrlOption !== 'string') throw new Error('You must provide a callback url to register a twitter webhook');
@@ -178,12 +178,12 @@ module.exports = function userActivityWebhook(config) {
         options.method = 'POST';
 
         return sendApiRequest(options)
-            .then(function (response) {
-                return response.body;
-            });
+        .then(function (response) {
+            return response.body;
+        });
     };
 
-    middleware.unregister = function unregister(args = {}) {
+    middleware.unregister = function unregister (args = {}) {
         const options = prepareAppContextRequest(args);
         if (typeof args.webhookId !== 'string') throw new Error('You must provide a webhookId');
 
@@ -191,34 +191,34 @@ module.exports = function userActivityWebhook(config) {
         options.method = 'DELETE';
 
         return sendApiRequest(options)
-            .then(function (response) {
-                // TODO EMIT DELETE EVENT
-            });
+        .then(function (response) {
+            // TODO EMIT DELETE EVENT
+        });
     };
 
-    middleware.getWebhooks = function getWebhooks(args = {}) {
+    middleware.getWebhooks = function getWebhooks (args = {}) {
         return prepareAppOnlyRequest(args)
-            .then(options => {
-                options.uri = `${TWITTER_API_URI}account_activity/all/webhooks.json`;
-                options.method = 'GET';
+        .then(options => {
+            options.uri = `${TWITTER_API_URI}account_activity/all/webhooks.json`;
+            options.method = 'GET';
 
-                return sendApiRequest(options)
-                    .then(function (response) {
-                        return response.body;
-                    });
+            return sendApiRequest(options)
+            .then(function (response) {
+                return response.body;
             });
+        });
     };
 
-    middleware.getWebhook = function getWebhook(args = {}) {
+    middleware.getWebhook = function getWebhook (args = {}) {
         const options = prepareAppContextRequest(args);
 
         options.uri = `${TWITTER_API_URI}account_activity/all/${environment}/webhooks.json`;
         options.method = 'GET';
 
         return sendApiRequest(options)
-            .then(function (response) {
-                return response.body;
-            });
+        .then(function (response) {
+            return response.body;
+        });
     };
 
     middleware.triggerChallengeResponseCheck = function (args = {}) {
@@ -234,15 +234,15 @@ module.exports = function userActivityWebhook(config) {
 
     middleware.getSubscriptionsCount = function (args = {}) {
         return prepareAppOnlyRequest(args)
-            .then(options => {
-                options.uri = `${TWITTER_API_URI}account_activity/subscriptions/list.json`;
-                options.method = 'GET';
+        .then(options => {
+            options.uri = `${TWITTER_API_URI}account_activity/subscriptions/list.json`;
+            options.method = 'GET';
 
-                return sendApiRequest(options)
-                    .then(function (response) {
-                        return response.body;
-                    });
+            return sendApiRequest(options)
+            .then(function (response) {
+                return response.body;
             });
+        });
     };
 
     middleware.isSubscribed = function (args = {}) {
@@ -252,26 +252,26 @@ module.exports = function userActivityWebhook(config) {
         options.method = 'GET';
 
         return sendApiRequest(options)
-            .then(function (response) {
-                return response.statusCode === 204;
-            })
-            .catch(function (error) {
-                if (error.statusCode !== -1) return false;
-                throw error;
-            });
+        .then(function (response) {
+            return response.statusCode === 204;
+        })
+        .catch(function (error) {
+            if (error.statusCode !== -1) return false;
+            throw error;
+        });
     };
 
     middleware.getSubscriptions = function (args = {}) {
         return prepareAppOnlyRequest(args)
-            .then(options => {
-                options.uri = `${TWITTER_API_URI}account_activity/all/${environment}/subscriptions/list.json`;
-                options.method = 'GET';
+        .then(options => {
+            options.uri = `${TWITTER_API_URI}account_activity/all/${environment}/subscriptions/list.json`;
+            options.method = 'GET';
 
-                return sendApiRequest(options)
-                    .then(function (response) {
-                        return response.body.subscriptions;
-                    });
+            return sendApiRequest(options)
+            .then(function (response) {
+                return response.body.subscriptions;
             });
+        });
     };
 
     middleware.getUserActivity = function (args) {
@@ -316,42 +316,42 @@ module.exports = function userActivityWebhook(config) {
 
     Object.defineProperty(middleware, 'appBearerToken', {
         get: function () { return appBearerToken; },
-        set: function (appBearerToken) { this.config({ appBearerToken }); }
+        set: function (appBearerToken) { this.config({appBearerToken}); }
     });
 
     Object.defineProperty(middleware, 'accessToken', {
         get: function () { return accessToken; },
-        set: function (accessToken) { this.config({ accessToken }); }
+        set: function (accessToken) { this.config({accessToken}); }
     });
 
     Object.defineProperty(middleware, 'accessTokenSecret', {
         get: function () { return accessTokenSecret; },
-        set: function (accessTokenSecret) { this.config({ accessTokenSecret }); }
+        set: function (accessTokenSecret) { this.config({accessTokenSecret}); }
     });
 
     Object.defineProperty(middleware, 'consumerKey', {
         get: function () { return consumerKey; },
-        set: function (consumerKey) { this.config({ consumerKey }); }
+        set: function (consumerKey) { this.config({consumerKey}); }
     });
 
     Object.defineProperty(middleware, 'consumerSecret', {
         get: function () { return consumerSecret; },
-        set: function (consumerSecret) { this.config({ consumerSecret }); }
+        set: function (consumerSecret) { this.config({consumerSecret}); }
     });
 
     Object.defineProperty(middleware, 'environment', {
         get: function () { return environment; },
-        set: function (environment) { this.config({ environment }); }
+        set: function (environment) { this.config({environment}); }
     });
 
     Object.defineProperty(middleware, 'route', {
         get: function () { return route; },
-        set: function (route) { this.config({ route }); }
+        set: function (route) { this.config({route}); }
     });
 
     Object.defineProperty(middleware, 'serverUrl', {
         get: function () { return serverUrl; },
-        set: function (serverUrl) { this.config({ serverUrl }); }
+        set: function (serverUrl) { this.config({serverUrl}); }
     });
 
     Object.defineProperty(middleware, 'callbackUrl', {

--- a/lib/user-activity-webhook.js
+++ b/lib/user-activity-webhook.js
@@ -8,14 +8,14 @@ const request = require('request');
 let twitterServerTimeOffset = 0;
 
 const TWITTER_API_URI = 'https://api.twitter.com/1.1/';
-const {sendApiRequest, rfc1738} = require('./helpers');
+const { sendApiRequest, rfc1738 } = require('./helpers');
 
-module.exports = function userActivityWebhook (config) {
+module.exports = function userActivityWebhook(config) {
     let serverUrl, route, callbackUrl, consumerSecret, consumerKey, accessToken, accessTokenSecret, environment, appBearerToken;
 
     const userActivityEmitters = new Map();
 
-    function prepareUserContextRequest (args) {
+    function prepareUserContextRequest(args) {
         if (!args.userId) throw new Error('Twitter webhooks : You must provide userId');
         if (!args.accessToken) throw new Error('Twitter webhooks : You must provide user accessToken');
         if (!args.accessTokenSecret) throw new Error('Twitter webhooks : You must provide user accessTokenSecret');
@@ -32,7 +32,7 @@ module.exports = function userActivityWebhook (config) {
         };
     }
 
-    function prepareAppContextRequest (args) {
+    function prepareAppContextRequest(args) {
         const accessTokenOption = args.accessToken || accessToken;
         const accessTokenSecretOption = args.accessTokenSecret || accessTokenSecret;
         if (typeof accessTokenOption !== 'string') throw new Error('Twitter webhooks : You must provide your app accessToken');
@@ -50,7 +50,7 @@ module.exports = function userActivityWebhook (config) {
         };
     }
 
-    function prepareAppOnlyRequest (args) {
+    function prepareAppOnlyRequest(args) {
         const appBearerTokenOption = args.appBearerToken || appBearerToken;
         if (typeof appBearerTokenOption !== 'string') {
 
@@ -65,22 +65,22 @@ module.exports = function userActivityWebhook (config) {
                     name: 'content-type',
                     value: 'application/x-www-form-urlencoded;charset=UTF-8'
                 }],
-                form: {grant_type: 'client_credentials'}
+                form: { grant_type: 'client_credentials' }
             })
-            .then((response) => {
-                try {
-                    appBearerToken = JSON.parse(response.body).access_token;
-                    if (typeof appBearerToken !== 'string') throw new Error();
-                } catch (e) {
-                    throw new Error('Twitter webhooks : cannot get app bearer token. Invalid response sent by twitter : ' + response.body);
-                }
-                return {
-                    json: true,
-                    auth: {
-                        bearer: appBearerToken
+                .then((response) => {
+                    try {
+                        appBearerToken = JSON.parse(response.body).access_token;
+                        if (typeof appBearerToken !== 'string') throw new Error();
+                    } catch (e) {
+                        throw new Error('Twitter webhooks : cannot get app bearer token. Invalid response sent by twitter : ' + response.body);
                     }
-                };
-            });
+                    return {
+                        json: true,
+                        auth: {
+                            bearer: appBearerToken
+                        }
+                    };
+                });
         } else {
             return Promise.resolve({
                 json: true,
@@ -91,54 +91,54 @@ module.exports = function userActivityWebhook (config) {
         }
     }
 
-    const middleware = function userActivityWebhookMiddleware (req, res, next) {
+    const middleware = function userActivityWebhookMiddleware(req, res, next) {
         switch (req.method) {
-        case 'GET':
-            if (req.query.crc_token) {
-                console.log({
-                    response_token: crypto.createHmac('sha256', consumerSecret).update(req.query.crc_token).digest('base64')
-                });
-                return res.json({
-                    response_token: 'sha256=' + crypto.createHmac('sha256', consumerSecret).update(req.query.crc_token).digest('base64')
-                });
-            }
-            break;
-        case 'POST':
-            res.sendStatus(200);
-            const payload = req.body;
-            if (typeof payload.for_user_id === 'string') {
-                const emitter = userActivityEmitters.get(payload.for_user_id);
-                for (let eventName in payload) {
-                    if (eventName === 'for_user_id') continue;
-                    const events = payload[eventName];
-                    eventName = eventName.replace('_events', '');
-                    if (Array.isArray(events)) {
-                        for (let i = 0; i < events.length; i++) {
-                            if (emitter) emitter.emit(eventName, events[i]);
-                            middleware.emit('event', eventName, payload.for_user_id, events[i]);
+            case 'GET':
+                if (req.query.crc_token) {
+                    console.log({
+                        response_token: crypto.createHmac('sha256', consumerSecret).update(req.query.crc_token).digest('base64')
+                    });
+                    return res.json({
+                        response_token: 'sha256=' + crypto.createHmac('sha256', consumerSecret).update(req.query.crc_token).digest('base64')
+                    });
+                }
+                break;
+            case 'POST':
+                res.sendStatus(200);
+                const payload = req.body;
+                if (typeof payload.for_user_id === 'string') {
+                    const emitter = userActivityEmitters.get(payload.for_user_id);
+                    for (let eventName in payload) {
+                        if (eventName === 'for_user_id') continue;
+                        const events = payload[eventName];
+                        eventName = eventName.replace('_events', '');
+                        if (Array.isArray(events)) {
+                            for (let i = 0; i < events.length; i++) {
+                                if (emitter) emitter.emit(eventName, events[i]);
+                                middleware.emit('event', eventName, payload.for_user_id, events[i]);
+                            }
+                        } else {
+                            if (emitter) emitter.emit(eventName, events);
+                            middleware.emit('event', eventName, payload.for_user_id, events);
                         }
-                    } else {
-                        if (emitter) emitter.emit(eventName, events);
-                        middleware.emit('event', eventName, payload.for_user_id, events);
+                    }
+                    return;
+                } else if (payload.user_event && typeof payload.user_event === 'object') {
+                    if (payload.user_event.revoke && typeof payload.user_event.revoke === 'object') {
+                        const emitter = userActivityEmitters.get(payload.user_event.revoke.source.user_id);
+                        if (emitter) emitter.emit('revoke', payload.user_event.revoke);
+                        middleware.emit('event', 'revoke', payload.user_event.revoke.source.user_id, payload.user_event.revoke);
+                        return;
                     }
                 }
-                return;
-            } else if (payload.user_event && typeof payload.user_event === 'object') {
-                if (payload.user_event.revoke && typeof payload.user_event.revoke === 'object') {
-                    const emitter = userActivityEmitters.get(payload.user_event.revoke.source.user_id);
-                    if (emitter) emitter.emit('revoke', payload.user_event.revoke);
-                    middleware.emit('event', 'revoke', payload.user_event.revoke.source.user_id, payload.user_event.revoke);
-                    return;
-                }
-            }
-            middleware.emit('unknown-event', payload);
-            break;
+                middleware.emit('unknown-event', payload);
+                break;
         }
 
         next();
     };
 
-    middleware.subscribe = function subscribe (args = {}) {
+    middleware.subscribe = function subscribe(args = {}) {
         const options = prepareUserContextRequest(args);
 
         args = Object.assign({}, args);
@@ -146,12 +146,12 @@ module.exports = function userActivityWebhook (config) {
         options.method = 'POST';
 
         return sendApiRequest(options)
-        .then(function () {
-            return middleware.getUserActivity(args);
-        });
+            .then(function () {
+                return middleware.getUserActivity(args);
+            });
     };
 
-    middleware.unsubscribe = function unsubscribe (args = {}) {
+    middleware.unsubscribe = function unsubscribe(args = {}) {
         const options = prepareUserContextRequest(args);
         const userId = args.userId;
 
@@ -159,17 +159,17 @@ module.exports = function userActivityWebhook (config) {
         options.method = 'DELETE';
 
         return sendApiRequest(options)
-        .then(function () {
-            const emitter = userActivityEmitters.get(userId);
-            if (emitter) {
-                emitter.emit('unsubscribe');
-                userActivityEmitters.delete(userId);
-                emitter.removeAllListeners();
-            }
-        });
+            .then(function () {
+                const emitter = userActivityEmitters.get(userId);
+                if (emitter) {
+                    emitter.emit('unsubscribe');
+                    userActivityEmitters.delete(userId);
+                    emitter.removeAllListeners();
+                }
+            });
     };
 
-    middleware.register = function register (args = {}) {
+    middleware.register = function register(args = {}) {
         const options = prepareAppContextRequest(args);
         const callbackUrlOption = args.callbackUrl || callbackUrl;
         if (typeof callbackUrlOption !== 'string') throw new Error('You must provide a callback url to register a twitter webhook');
@@ -178,12 +178,12 @@ module.exports = function userActivityWebhook (config) {
         options.method = 'POST';
 
         return sendApiRequest(options)
-        .then(function (response) {
-            return response.body;
-        });
+            .then(function (response) {
+                return response.body;
+            });
     };
 
-    middleware.unregister = function unregister (args = {}) {
+    middleware.unregister = function unregister(args = {}) {
         const options = prepareAppContextRequest(args);
         if (typeof args.webhookId !== 'string') throw new Error('You must provide a webhookId');
 
@@ -191,34 +191,34 @@ module.exports = function userActivityWebhook (config) {
         options.method = 'DELETE';
 
         return sendApiRequest(options)
-        .then(function (response) {
-            // TODO EMIT DELETE EVENT
-        });
-    };
-
-    middleware.getWebhooks = function getWebhooks (args = {}) {
-        return prepareAppOnlyRequest(args)
-        .then(options => {
-            options.uri = `${TWITTER_API_URI}account_activity/all/webhooks.json`;
-            options.method = 'GET';
-
-            return sendApiRequest(options)
             .then(function (response) {
-                return response.body;
+                // TODO EMIT DELETE EVENT
             });
-        });
     };
 
-    middleware.getWebhook = function getWebhook (args = {}) {
+    middleware.getWebhooks = function getWebhooks(args = {}) {
+        return prepareAppOnlyRequest(args)
+            .then(options => {
+                options.uri = `${TWITTER_API_URI}account_activity/all/webhooks.json`;
+                options.method = 'GET';
+
+                return sendApiRequest(options)
+                    .then(function (response) {
+                        return response.body;
+                    });
+            });
+    };
+
+    middleware.getWebhook = function getWebhook(args = {}) {
         const options = prepareAppContextRequest(args);
 
         options.uri = `${TWITTER_API_URI}account_activity/all/${environment}/webhooks.json`;
         options.method = 'GET';
 
         return sendApiRequest(options)
-        .then(function (response) {
-            return response.body;
-        });
+            .then(function (response) {
+                return response.body;
+            });
     };
 
     middleware.triggerChallengeResponseCheck = function (args = {}) {
@@ -234,44 +234,44 @@ module.exports = function userActivityWebhook (config) {
 
     middleware.getSubscriptionsCount = function (args = {}) {
         return prepareAppOnlyRequest(args)
-        .then(options => {
-            options.uri = `${TWITTER_API_URI}account_activity/subscriptions/list.json`;
-            options.method = 'GET';
+            .then(options => {
+                options.uri = `${TWITTER_API_URI}account_activity/subscriptions/list.json`;
+                options.method = 'GET';
 
-            return sendApiRequest(options)
-            .then(function (response) {
-                return response.body;
+                return sendApiRequest(options)
+                    .then(function (response) {
+                        return response.body;
+                    });
             });
-        });
     };
 
     middleware.isSubscribed = function (args = {}) {
         const options = prepareUserContextRequest(args);
 
-        options.uri = `${TWITTER_API_URI}account_activity/subscriptions/list.json`;
+        options.uri = `${TWITTER_API_URI}account_activity/all/${environment}/subscriptions.json`;
         options.method = 'GET';
 
         return sendApiRequest(options)
-        .then(function (response) {
-            return response.statusCode === 204;
-        })
-        .catch(function (error) {
-            if (error.statusCode !== -1) return false;
-            throw error;
-        });
+            .then(function (response) {
+                return response.statusCode === 204;
+            })
+            .catch(function (error) {
+                if (error.statusCode !== -1) return false;
+                throw error;
+            });
     };
 
     middleware.getSubscriptions = function (args = {}) {
         return prepareAppOnlyRequest(args)
-        .then(options => {
-            options.uri = `${TWITTER_API_URI}account_activity/all/${environment}/subscriptions/list.json`;
-            options.method = 'GET';
+            .then(options => {
+                options.uri = `${TWITTER_API_URI}account_activity/all/${environment}/subscriptions/list.json`;
+                options.method = 'GET';
 
-            return sendApiRequest(options)
-            .then(function (response) {
-                return response.body.subscriptions;
+                return sendApiRequest(options)
+                    .then(function (response) {
+                        return response.body.subscriptions;
+                    });
             });
-        });
     };
 
     middleware.getUserActivity = function (args) {
@@ -316,42 +316,42 @@ module.exports = function userActivityWebhook (config) {
 
     Object.defineProperty(middleware, 'appBearerToken', {
         get: function () { return appBearerToken; },
-        set: function (appBearerToken) { this.config({appBearerToken}); }
+        set: function (appBearerToken) { this.config({ appBearerToken }); }
     });
 
     Object.defineProperty(middleware, 'accessToken', {
         get: function () { return accessToken; },
-        set: function (accessToken) { this.config({accessToken}); }
+        set: function (accessToken) { this.config({ accessToken }); }
     });
 
     Object.defineProperty(middleware, 'accessTokenSecret', {
         get: function () { return accessTokenSecret; },
-        set: function (accessTokenSecret) { this.config({accessTokenSecret}); }
+        set: function (accessTokenSecret) { this.config({ accessTokenSecret }); }
     });
 
     Object.defineProperty(middleware, 'consumerKey', {
         get: function () { return consumerKey; },
-        set: function (consumerKey) { this.config({consumerKey}); }
+        set: function (consumerKey) { this.config({ consumerKey }); }
     });
 
     Object.defineProperty(middleware, 'consumerSecret', {
         get: function () { return consumerSecret; },
-        set: function (consumerSecret) { this.config({consumerSecret}); }
+        set: function (consumerSecret) { this.config({ consumerSecret }); }
     });
 
     Object.defineProperty(middleware, 'environment', {
         get: function () { return environment; },
-        set: function (environment) { this.config({environment}); }
+        set: function (environment) { this.config({ environment }); }
     });
 
     Object.defineProperty(middleware, 'route', {
         get: function () { return route; },
-        set: function (route) { this.config({route}); }
+        set: function (route) { this.config({ route }); }
     });
 
     Object.defineProperty(middleware, 'serverUrl', {
         get: function () { return serverUrl; },
-        set: function (serverUrl) { this.config({serverUrl}); }
+        set: function (serverUrl) { this.config({ serverUrl }); }
     });
 
     Object.defineProperty(middleware, 'callbackUrl', {


### PR DESCRIPTION
Looks like the endpoint for `isSubscribed` is no longer a thing for the current Twitter dev API. 

Made the change to use the latest versions endpoint.

[Twitter Account Activity Docs](https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#get-account-activity-all-env-name-subscriptions) for reference